### PR TITLE
Backport to swift 5.9

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version: 6.0
+// swift-tools-version: 5.9
 
 import PackageDescription
 


### PR DESCRIPTION
The latest version of xcode that the 2017 macbook pro supports is macOS 13.7, and the latest version of xcode which that supports is Xcode 15.2, which ships with Swift 5.9. This patch allows building on Swift 5.9